### PR TITLE
Avoid compilation errors when platform does not specify MPU structure.

### DIFF
--- a/architectures/armv7-m/debug_cm3.h
+++ b/architectures/armv7-m/debug_cm3.h
@@ -681,6 +681,7 @@ static __INLINE void initFPB(void)
     enableFPB();
 }
 
+#if defined (__MPU_PRESENT) && (__MPU_PRESENT == 1U)
 
 /* Memory Protection Unit Type Register Bits. */
 /* Number of instruction regions supported by MPU.  0 for Cortex-M3 */
@@ -849,6 +850,8 @@ static __INLINE uint32_t getMPURegionAttributeAndSize(void)
 
     return MPU->RASR;
 }
+
+#endif
 
 static __INLINE uint32_t getCurrentlyExecutingExceptionNumber(void)
 {


### PR DESCRIPTION
Thanks for the great project!

When compiling on GD32F103, I ran into errors about MPU being undefined.
Like many other Cortex-M3 devices, GD32F103 does not have MPU and defines `__MPU_PRESENT` as 0.
However, unlike e.g. STM32, it also does not define the `MPU_Type` and `MPU` structures at all.

This caused some compilation problems with the inline functions in `debug_cm3.h`.
This pull request adds a simple `#if` around them.

I can confirm that this works on GD32F103 now to some extent, though I'm still having some problem with breakpoints crashing.