### PR TITLE
Rename posix4win.h to signal.h

### DIFF
--- a/architectures/armv7-m/armv7-m.c
+++ b/architectures/armv7-m/armv7-m.c
@@ -15,7 +15,7 @@
 /* Routines to expose the Cortex-M functionality to the mri debugger. */
 #include <errno.h>
 #include <string.h>
-#include <signal.h>
+#include <core/signal.h>
 #include <core/core.h>
 #include <core/platforms.h>
 #include <core/gdb_console.h>

--- a/core/cmd_file.c
+++ b/core/cmd_file.c
@@ -13,8 +13,8 @@
    limitations under the License.
 */
 /* Handling and issuing routines for gdb file commands. */
-#include <signal.h>
 #include <string.h>
+#include <core/signal.h>
 #include <core/fileio.h>
 #include <core/core.h>
 #include <core/cmd_common.h>

--- a/core/cmd_registers.c
+++ b/core/cmd_registers.c
@@ -13,7 +13,7 @@
    limitations under the License.
 */
 /* Command handler for gdb commands related to CPU registers. */
-#include <signal.h>
+#include <core/signal.h>
 #include <core/cmd_common.h>
 #include <core/platforms.h>
 #include <core/buffer.h>

--- a/core/mri.c
+++ b/core/mri.c
@@ -15,7 +15,6 @@
 /* Monitor for Remote Inspection - Provides core mri routines to initialize the debug monitor, query its state, and
    invoke it into action when a debug event occurs on the target hardware. */
 #include <string.h>
-#include <signal.h>
 #include <errno.h>
 #include <core/mri.h>
 #include <core/buffer.h>
@@ -25,7 +24,7 @@
 #include <core/token.h>
 #include <core/core.h>
 #include <core/platforms.h>
-#include <core/posix4win.h>
+#include <core/signal.h>
 #include <core/semihost.h>
 #include <core/cmd_common.h>
 #include <core/cmd_file.h>

--- a/core/signal.h
+++ b/core/signal.h
@@ -13,15 +13,21 @@
    limitations under the License.
 */
 /* Monitor for Remote Inspection. */
-#ifndef POSIX4WIN_H_
-#define POSIX4WIN_H_
-#ifdef WIN32
+#ifndef SIGNAL_H_
+#define SIGNAL_H_
 
+#include <signal.h>
 
+#ifndef SIGTRAP
 #define SIGTRAP 5
+#endif
+
+#ifndef SIGBUS
 #define SIGBUS  10
+#endif
+
+#ifndef SIGSTOP
 #define SIGSTOP 18
+#endif
 
-
-#endif /* WIN32 */
-#endif /* POSIX4WIN_H_ */
+#endif /* SIGNAL_H_ */

--- a/tests/mocks/platformMock.cpp
+++ b/tests/mocks/platformMock.cpp
@@ -13,13 +13,12 @@
    limitations under the License.
 */
 #include <assert.h>
-#include <signal.h>
 #include <string.h>
 
 extern "C"
 {
 #include <core/platforms.h>
-#include <core/posix4win.h>
+#include <core/signal.h>
 #include <core/semihost.h>
 #include <core/buffer.h>
 #include <core/try_catch.h>


### PR DESCRIPTION
and define SIGTRAP/SIGBUS/SIGSTOP if not done by the system signal.h
