### PR TITLE
Remove "extern int errno" from architectures/armv7-m/armv7-m.c

### DIFF
--- a/architectures/armv7-m/armv7-m.c
+++ b/architectures/armv7-m/armv7-m.c
@@ -22,10 +22,6 @@
 #include "debug_cm3.h"
 #include "armv7-m.h"
 
-/* Disable any macro used for errno and use the int global instead. */
-#undef errno
-extern int errno;
-
 /* Fake stack used when task encounters stacking/unstacking fault. */
 static const uint32_t  g_fakeStack[] = { 0xDEADDEAD, 0xDEADDEAD, 0xDEADDEAD, 0xDEADDEAD,
                                          0xDEADDEAD, 0xDEADDEAD, 0xDEADDEAD, 0xDEADDEAD,


### PR DESCRIPTION
since no all libc implement errno as an normal integer
