### PR TITLE
Remove mri prefix from the whole code base to unify the usage

### DIFF
--- a/architectures/armv7-m/armv7-m.c
+++ b/architectures/armv7-m/armv7-m.c
@@ -1473,7 +1473,7 @@ int mriFaultHandler(uint32_t psp, uint32_t msp, uint32_t excReturn)
     {
         /* Exception occurred in code too high priority to debug so start a crash dump.
 
-           Returns -1 to let asm routine know that it should call mriPlatform_HandleFaultFromHighPriorityCode() to handle
+           Returns -1 to let asm routine know that it should call Platform_HandleFaultFromHighPriorityCode() to handle
            this special case by doing something like dumping a crash dump since MRI can't debug it.
         */
         return -1;

--- a/architectures/armv7-m/armv7-m_asm.S
+++ b/architectures/armv7-m/armv7-m_asm.S
@@ -90,7 +90,7 @@
             EXC_RETURN (exception LR)
 
        Once the registers are stacked, mriDebugException is called and upon return, the values are popped off of the
-       stack and placed back into the original registers, except for PSP, PRIMASK, FAULTMASK, and CONTROL which always
+       stack and placed back into the original registers, except for PRIMASK, FAULTMASK, and CONTROL which always
        maintain their original value.
     */
 mriExceptionHandler:

--- a/boards/bambino210/bambino210.c
+++ b/boards/bambino210/bambino210.c
@@ -26,13 +26,13 @@ void Platform_Init(Token* pParameterTokens)
 }
 
 
-const uint8_t* mriPlatform_GetUid(void)
+const uint8_t* Platform_GetUid(void)
 {
     return NULL;
 }
 
 
-uint32_t mriPlatform_GetUidSize(void)
+uint32_t Platform_GetUidSize(void)
 {
     return 0;
 }

--- a/boards/mbed1768/mbed1768.c
+++ b/boards/mbed1768/mbed1768.c
@@ -90,13 +90,13 @@ static void setMbedDetectedFlag(void)
 }
 
 
-const uint8_t* mriPlatform_GetUid(void)
+const uint8_t* Platform_GetUid(void)
 {
     return g_state.mbedUid;
 }
 
 
-uint32_t mriPlatform_GetUidSize(void)
+uint32_t Platform_GetUidSize(void)
 {
     return sizeof(g_state.mbedUid);
 }

--- a/boards/nrf52dk/nrf52dk.c
+++ b/boards/nrf52dk/nrf52dk.c
@@ -33,13 +33,13 @@ void Platform_Init(Token* pParameterTokens)
 }
 
 
-const uint8_t* mriPlatform_GetUid(void)
+const uint8_t* Platform_GetUid(void)
 {
     return NULL;
 }
 
 
-uint32_t mriPlatform_GetUidSize(void)
+uint32_t Platform_GetUidSize(void)
 {
     return 0;
 }

--- a/boards/stm32f429-disco/stm32f429-disco.c
+++ b/boards/stm32f429-disco/stm32f429-disco.c
@@ -27,13 +27,13 @@ void Platform_Init(Token* pParameterTokens)
 }
 
 
-const uint8_t* mriPlatform_GetUid(void)
+const uint8_t* Platform_GetUid(void)
 {
     return NULL;
 }
 
 
-uint32_t mriPlatform_GetUidSize(void)
+uint32_t Platform_GetUidSize(void)
 {
     return 0;
 }

--- a/core/cmd_thread.c
+++ b/core/cmd_thread.c
@@ -28,7 +28,7 @@
     Where xxxxxxxx is the hexadecimal representation of the ID for the thread to use for future register read/write
     commands.
 */
-uint32_t mriCmd_HandleThreadContextCommand(void)
+uint32_t HandleThreadContextCommand(void)
 {
     Buffer*     pBuffer = GetBuffer();
 

--- a/core/context.c
+++ b/core/context.c
@@ -36,7 +36,7 @@ uint32_t Context_Count(MriContext* pThis)
     return count;
 }
 
-uint32_t mriContext_Get(const MriContext* pThis, uint32_t index)
+uint32_t Context_Get(const MriContext* pThis, uint32_t index)
 {
     uint32_t i;
     uint32_t count = 0;
@@ -53,7 +53,7 @@ uint32_t mriContext_Get(const MriContext* pThis, uint32_t index)
     __throw_and_return(bufferOverrunException, 0);
 }
 
-void mriContext_Set(MriContext* pThis, uint32_t index, uint32_t newValue)
+void Context_Set(MriContext* pThis, uint32_t index, uint32_t newValue)
 {
     uint32_t i;
     uint32_t count = 0;

--- a/core/mri.c
+++ b/core/mri.c
@@ -329,7 +329,7 @@ void GdbCommandHandlingLoop(void)
     } while (!startDebuggeeUpAgain);
 }
 
-__attribute__((weak)) uint32_t  mriPlatform_HandleGDBCommand(Buffer* pBuffer);
+__attribute__((weak)) uint32_t Platform_HandleGDBCommand(Buffer* pBuffer);
 static int handleGDBCommand(void)
 {
     Buffer*         pBuffer = GetBuffer();
@@ -364,8 +364,8 @@ static int handleGDBCommand(void)
 
     getPacketFromGDB();
 
-    if (mriPlatform_HandleGDBCommand)
-        handlerResult = mriPlatform_HandleGDBCommand(pBuffer);
+    if (Platform_HandleGDBCommand)
+        handlerResult = Platform_HandleGDBCommand(pBuffer);
     if (handlerResult == 0)
     {
         Buffer_Reset(pBuffer);

--- a/core/platforms.h
+++ b/core/platforms.h
@@ -160,6 +160,7 @@ void            mriPlatform_HandleFaultFromHighPriorityCode(void);
 #define Platform_CommReceiveChar                            mriPlatform_CommReceiveChar
 #define Platform_CommSendBuffer                             mriPlatform_CommSendBuffer
 #define Platform_CommSendChar                               mriPlatform_CommSendChar
+#define Platform_HandleGDBCommand                           mriPlatform_HandleGDBCommand
 #define Platform_DetermineCauseOfException                  mriPlatform_DetermineCauseOfException
 #define Platform_GetTrapReason                              mriPlatform_GetTrapReason
 #define Platform_DisplayFaultCauseToGdbConsole              mriPlatform_DisplayFaultCauseToGdbConsole
@@ -197,6 +198,6 @@ void            mriPlatform_HandleFaultFromHighPriorityCode(void);
 #define Platform_RtosIsSetThreadStateSupported              mriPlatform_RtosIsSetThreadStateSupported
 #define Platform_RtosSetThreadState                         mriPlatform_RtosSetThreadState
 #define Platform_RtosRestorePrevThreadState                 mriPlatform_RtosRestorePrevThreadState
-#define Platform_HandleFaultFromHighPriorityCode                  mriPlatform_HandleFaultFromHighPriorityCode
+#define Platform_HandleFaultFromHighPriorityCode            mriPlatform_HandleFaultFromHighPriorityCode
 
 #endif /* PLATFORMS_H_ */

--- a/devices/lpc176x/lpc176x_uart.c
+++ b/devices/lpc176x/lpc176x_uart.c
@@ -432,7 +432,7 @@ uint32_t Platform_CommHasReceiveData(void)
 }
 
 
-uint32_t  mriPlatform_CommHasTransmitCompleted(void)
+uint32_t  Platform_CommHasTransmitCompleted(void)
 {
     static const uint8_t transmitterEmpty = 1 << 6;
 

--- a/devices/lpc43xx/lpc43xx_uart.c
+++ b/devices/lpc43xx/lpc43xx_uart.c
@@ -665,7 +665,7 @@ uint32_t Platform_CommHasReceiveData(void)
 }
 
 
-uint32_t  mriPlatform_CommHasTransmitCompleted(void)
+uint32_t  Platform_CommHasTransmitCompleted(void)
 {
     static const uint8_t transmitterEmpty = 1 << 6;
 

--- a/devices/stm32f429xx/stm32f429xx_usart.c
+++ b/devices/stm32f429xx/stm32f429xx_usart.c
@@ -498,7 +498,7 @@ uint32_t Platform_CommHasReceiveData(void)
     return mriStm32f429xxState.pCurrentUart->pUartRegisters->SR & USART_SR_RXNE;
 }
 
-uint32_t mriPlatform_CommHasTransmitCompleted(void)
+uint32_t Platform_CommHasTransmitCompleted(void)
 {
     return mriStm32f429xxState.pCurrentUart->pUartRegisters->SR & USART_SR_TC;
 }

--- a/notes/mri-porting.md
+++ b/notes/mri-porting.md
@@ -140,13 +140,13 @@ void Platform_Init(Token* pParameterTokens)
 }
 
 
-const uint8_t* mriPlatform_GetUid(void)
+const uint8_t* Platform_GetUid(void)
 {
     return NULL;
 }
 
 
-uint32_t mriPlatform_GetUidSize(void)
+uint32_t Platform_GetUidSize(void)
 {
     return 0;
 }

--- a/semihost/newlib/semihost_newlib.c
+++ b/semihost/newlib/semihost_newlib.c
@@ -168,8 +168,8 @@ static int handleNewlibSemihostRenameRequest(PlatformSemihostParameters* pSemiho
 
 static int handleNewlibSemihostGetErrNoRequest(PlatformSemihostParameters* pSemihostParameters)
 {
-    mriCore_SetSemihostReturnValues(mriCore_GetSemihostErrno(), 0);
-    mriCore_FlagSemihostCallAsHandled();
+    SetSemihostReturnValues(GetSemihostErrno(), 0);
+    FlagSemihostCallAsHandled();
     return 1;
 }
 
@@ -181,7 +181,7 @@ static int handleNewlibSemihostSetHooksRequest(PlatformSemihostParameters* pSemi
 
     mriCoreSetDebuggerHooks(pEnteringHook, pLeavingHook, pvContext);
 
-    mriCore_SetSemihostReturnValues(0, 0);
-    mriCore_FlagSemihostCallAsHandled();
+    SetSemihostReturnValues(0, 0);
+    FlagSemihostCallAsHandled();
     return 1;
 }

--- a/tests/mocks/platformMock.cpp
+++ b/tests/mocks/platformMock.cpp
@@ -284,12 +284,12 @@ int platformMock_GetLeavingDebuggerCalls(void)
 }
 
 // Stubs called by MRI core.
-void mriPlatform_EnteringDebugger(void)
+void Platform_EnteringDebugger(void)
 {
     g_enteringDebuggerCount++;
 }
 
-void mriPlatform_LeavingDebugger(void)
+void Platform_LeavingDebugger(void)
 {
     g_leavingDebuggerCount++;
 }
@@ -309,12 +309,12 @@ void platformMock_SetPacketBufferSize(uint32_t setValue)
 }
 
 // Packet Buffer stubs called by MRI core.
-char* mriPlatform_GetPacketBuffer(void)
+char* Platform_GetPacketBuffer(void)
 {
     return g_packetBuffer;
 }
 
-uint32_t  mriPlatform_GetPacketBufferSize(void)
+uint32_t  Platform_GetPacketBufferSize(void)
 {
     return g_packetBufferSize;
 }
@@ -336,12 +336,12 @@ int platformMock_GetHandleSemihostRequestCalls(void)
 }
 
 // Semihost stubs called by MRI core.
-int mriSemihost_IsDebuggeeMakingSemihostCall(void)
+int Semihost_IsDebuggeeMakingSemihostCall(void)
 {
     return g_isDebuggeeMakingSemihostCall;
 }
 
-int mriSemihost_HandleSemihostRequest(void)
+int Semihost_HandleSemihostRequest(void)
 {
     g_getHandleSemihostRequestCount++;
     return TRUE;
@@ -371,17 +371,17 @@ void platformMock_SetTrapReason(const PlatformTrapReason* pReason)
 
 
 // Fault/Exception stubs called by MRI core.
-uint8_t mriPlatform_DetermineCauseOfException(void)
+uint8_t Platform_DetermineCauseOfException(void)
 {
     return g_causeOfException;
 }
 
-PlatformTrapReason mriPlatform_GetTrapReason(void)
+PlatformTrapReason Platform_GetTrapReason(void)
 {
     return g_trapReason;
 }
 
-void mriPlatform_DisplayFaultCauseToGdbConsole(void)
+void Platform_DisplayFaultCauseToGdbConsole(void)
 {
     g_displayFaultCauseToGdbConsoleCount++;
 }
@@ -415,29 +415,29 @@ uint32_t platformMock_GetProgramCounterValue(void)
 }
 
 // Stubs called by MRI core.
-PlatformInstructionType mriPlatform_TypeOfCurrentInstruction(void)
+PlatformInstructionType Platform_TypeOfCurrentInstruction(void)
 {
     return g_instructionType;
 }
 
-void mriPlatform_AdvanceProgramCounterToNextInstruction(void)
+void Platform_AdvanceProgramCounterToNextInstruction(void)
 {
     g_advanceProgramCounterToNextInstruction++;
     g_programCounter += 4;
 }
 
-void mriPlatform_SetProgramCounter(uint32_t newPC)
+void Platform_SetProgramCounter(uint32_t newPC)
 {
     g_programCounter = newPC;
     g_setProgramCounterCalls++;
 }
 
-int mriPlatform_WasProgramCounterModifiedByUser(void)
+int Platform_WasProgramCounterModifiedByUser(void)
 {
     return FALSE;
 }
 
-uint32_t  mriPlatform_GetProgramCounter(void)
+uint32_t  Platform_GetProgramCounter(void)
 {
     return g_programCounter;
 }
@@ -460,7 +460,7 @@ void platformMock_SingleStepShouldAdvancePC(bool enable)
     g_singleSteppingShouldAdvancePC = enable;
 }
 
-void mriPlatform_EnableSingleStep(void)
+void Platform_EnableSingleStep(void)
 {
     if (g_singleSteppingShouldAdvancePC)
         g_programCounter += 4;
@@ -468,13 +468,13 @@ void mriPlatform_EnableSingleStep(void)
         g_singleStepping = TRUE;
 }
 
-void mriPlatform_DisableSingleStep(void)
+void Platform_DisableSingleStep(void)
 {
     if (!g_singleSteppingForced)
         g_singleStepping = FALSE;
 }
 
-int mriPlatform_IsSingleStepping(void)
+int Platform_IsSingleStepping(void)
 {
     return g_singleStepping;
 }
@@ -489,7 +489,7 @@ void platformMock_FaultOnSpecificMemoryCall(int callToFail)
 }
 
 // Stub called by MRI core.
-int mriPlatform_WasMemoryFaultEncountered(void)
+int Platform_WasMemoryFaultEncountered(void)
 {
     if (g_callToFail == 0)
         return FALSE;
@@ -517,7 +517,7 @@ MriContext* platformMock_GetContext(void)
 }
 
 // Stubs called from MRI core.
-void mriPlatform_WriteTResponseRegistersToBuffer(Buffer* pBuffer)
+void Platform_WriteTResponseRegistersToBuffer(Buffer* pBuffer)
 {
     Buffer_WriteString(pBuffer, "responseT");
 }
@@ -635,7 +635,7 @@ void platformMock_ClearHardwareWatchpointException(uint32_t exceptionToThrow)
 }
 
 // Stubs called from MRI core.
-__throws void  mriPlatform_SetHardwareBreakpointOfGdbKind(uint32_t address, uint32_t kind)
+__throws void  Platform_SetHardwareBreakpointOfGdbKind(uint32_t address, uint32_t kind)
 {
     g_setHardwareBreakpointCalls++;
     g_setHardwareBreakpointAddressArg = address;
@@ -644,7 +644,7 @@ __throws void  mriPlatform_SetHardwareBreakpointOfGdbKind(uint32_t address, uint
         __throw(g_setHardwareBreakpointException);
 }
 
-__throws void  mriPlatform_SetHardwareBreakpoint(uint32_t address)
+__throws void  Platform_SetHardwareBreakpoint(uint32_t address)
 {
     g_setHardwareBreakpointCalls++;
     g_setHardwareBreakpointAddressArg = address;
@@ -653,7 +653,7 @@ __throws void  mriPlatform_SetHardwareBreakpoint(uint32_t address)
         __throw(g_setHardwareBreakpointException);
 }
 
-__throws void  mriPlatform_ClearHardwareBreakpointOfGdbKind(uint32_t address, uint32_t kind)
+__throws void  Platform_ClearHardwareBreakpointOfGdbKind(uint32_t address, uint32_t kind)
 {
     g_clearHardwareBreakpointCalls++;
     g_clearHardwareBreakpointAddressArg = address;
@@ -662,7 +662,7 @@ __throws void  mriPlatform_ClearHardwareBreakpointOfGdbKind(uint32_t address, ui
         __throw(g_clearHardwareBreakpointException);
 }
 
-__throws void  mriPlatform_ClearHardwareBreakpoint(uint32_t address)
+__throws void  Platform_ClearHardwareBreakpoint(uint32_t address)
 {
     g_clearHardwareBreakpointCalls++;
     g_clearHardwareBreakpointAddressArg = address;
@@ -671,7 +671,7 @@ __throws void  mriPlatform_ClearHardwareBreakpoint(uint32_t address)
         __throw(g_clearHardwareBreakpointException);
 }
 
-__throws void  mriPlatform_SetHardwareWatchpoint(uint32_t address, uint32_t size,  PlatformWatchpointType type)
+__throws void  Platform_SetHardwareWatchpoint(uint32_t address, uint32_t size,  PlatformWatchpointType type)
 {
     g_setHardwareWatchpointCalls++;
     g_setHardwareWatchpointAddressArg = address;
@@ -681,7 +681,7 @@ __throws void  mriPlatform_SetHardwareWatchpoint(uint32_t address, uint32_t size
         __throw(g_setHardwareWatchpointException);
 }
 
-__throws void  mriPlatform_ClearHardwareWatchpoint(uint32_t address, uint32_t size,  PlatformWatchpointType type)
+__throws void  Platform_ClearHardwareWatchpoint(uint32_t address, uint32_t size,  PlatformWatchpointType type)
 {
     g_clearHardwareWatchpointCalls++;
     g_clearHardwareWatchpointAddressArg = address;
@@ -698,22 +698,22 @@ static char g_deviceMemoryMapXml[] = "TEST";
 static char g_targetXml[] = "test!";
 
 // Stubs called by MRI core.
-uint32_t mriPlatform_GetDeviceMemoryMapXmlSize(void)
+uint32_t Platform_GetDeviceMemoryMapXmlSize(void)
 {
     return sizeof(g_deviceMemoryMapXml) - 1;
 }
 
-const char*  mriPlatform_GetDeviceMemoryMapXml(void)
+const char*  Platform_GetDeviceMemoryMapXml(void)
 {
     return g_deviceMemoryMapXml;
 }
 
-uint32_t mriPlatform_GetTargetXmlSize(void)
+uint32_t Platform_GetTargetXmlSize(void)
 {
     return sizeof(g_targetXml) - 1;
 }
 
-const char*  mriPlatform_GetTargetXml(void)
+const char*  Platform_GetTargetXml(void)
 {
     return g_targetXml;
 }
@@ -735,7 +735,7 @@ int platformMock_GetSemihostCallErrno(void)
 }
 
 // Stubs called by MRI core.
-void mriPlatform_SetSemihostCallReturnAndErrnoValues(int returnValue, int err)
+void Platform_SetSemihostCallReturnAndErrnoValues(int returnValue, int err)
 {
     g_semihostCallReturnValue = returnValue;
     g_semihostCallErrno = err;
@@ -983,7 +983,7 @@ void platformMock_Uninit(void)
 
 
 // Stubs for Platform APIs that act as NOPs when called from mriCore during testing.
-extern "C" uint32_t  mriPlatform_HandleGDBCommand(Buffer* pBuffer)
+extern "C" uint32_t  Platform_HandleGDBCommand(Buffer* pBuffer)
 {
     return 0;
 }

--- a/tests/tests/mriTests.cpp
+++ b/tests/tests/mriTests.cpp
@@ -172,7 +172,7 @@ TEST(Mri, mriCoreSetTempBreakpoint_ShouldSucceedAndSetHardwareBreakpointAtSpecif
 {
     mriInit("MRI_UART_MBED_USB");
 
-    CHECK_TRUE( mriCore_SetTempBreakpoint(0xBAADF00D, NULL, NULL) );
+    CHECK_TRUE( SetTempBreakpoint(0xBAADF00D, NULL, NULL) );
     CHECK_EQUAL( 1, platformMock_SetHardwareBreakpointCalls() );
     CHECK_EQUAL( 0xBAADF00D & ~1, platformMock_SetHardwareBreakpointAddressArg() );
     CHECK_EQUAL( 0xFFFFFFFF, platformMock_SetHardwareBreakpointKindArg() );
@@ -182,12 +182,12 @@ TEST(Mri, mriCoreSetTempBreakpoint_TryToSetBreakpointTwiceAndSecondCallFails)
 {
     mriInit("MRI_UART_MBED_USB");
 
-    CHECK_TRUE( mriCore_SetTempBreakpoint(0xBAADF00D, NULL, NULL) );
+    CHECK_TRUE( SetTempBreakpoint(0xBAADF00D, NULL, NULL) );
     CHECK_EQUAL( 1, platformMock_SetHardwareBreakpointCalls() );
     CHECK_EQUAL( 0xBAADF00D & ~1, platformMock_SetHardwareBreakpointAddressArg() );
     CHECK_EQUAL( 0xFFFFFFFF, platformMock_SetHardwareBreakpointKindArg() );
 
-    CHECK_FALSE( mriCore_SetTempBreakpoint(0xBAADF00D, NULL, NULL) );
+    CHECK_FALSE( SetTempBreakpoint(0xBAADF00D, NULL, NULL) );
     // Should still just have hardware breakpoint from first successful call.
     CHECK_EQUAL( 1, platformMock_SetHardwareBreakpointCalls() );
     CHECK_EQUAL( 0xBAADF00D & ~1, platformMock_SetHardwareBreakpointAddressArg() );
@@ -199,7 +199,7 @@ TEST(Mri, mriCoreSetTempBreakpoint_SetHardwareBreakpointThrows_ShouldFail_Except
     mriInit("MRI_UART_MBED_USB");
 
     platformMock_SetHardwareBreakpointException(exceededHardwareResourcesException);
-    CHECK_FALSE( mriCore_SetTempBreakpoint(0xBAADF00D, NULL, NULL) );
+    CHECK_FALSE( SetTempBreakpoint(0xBAADF00D, NULL, NULL) );
     CHECK_EQUAL( noException, getExceptionCode() );
 }
 
@@ -207,9 +207,9 @@ TEST(Mri, mriCoreSetTempBreakpoint_RunMriDebugException_DontHitBreakpoint_Breakp
 {
     mriInit("MRI_UART_MBED_USB");
 
-    mriCore_SetTempBreakpoint(0xBAADF00D, NULL, NULL);
+    SetTempBreakpoint(0xBAADF00D, NULL, NULL);
 
-    mriPlatform_SetProgramCounter(0xBAADF00B);
+    Platform_SetProgramCounter(0xBAADF00B);
     platformMock_CommInitReceiveChecksummedData("+$c#");
         mriDebugException(platformMock_GetContext());
     STRCMP_EQUAL ( platformMock_CommChecksumData("$T05responseT#+"), platformMock_CommGetTransmittedData() );
@@ -222,9 +222,9 @@ TEST(Mri, mriCoreSetTempBreakpoint_RunMriDebugException_HitBreakpoint_Breakpoint
 {
     mriInit("MRI_UART_MBED_USB");
 
-    mriCore_SetTempBreakpoint(0xBAADF00D, NULL, NULL);
+    SetTempBreakpoint(0xBAADF00D, NULL, NULL);
 
-    mriPlatform_SetProgramCounter(0xBAADF00D);
+    Platform_SetProgramCounter(0xBAADF00D);
     platformMock_CommInitReceiveChecksummedData("+$c#");
         mriDebugException(platformMock_GetContext());
     STRCMP_EQUAL ( platformMock_CommChecksumData("$T05responseT#+"), platformMock_CommGetTransmittedData() );
@@ -236,9 +236,9 @@ TEST(Mri, mriCoreSetTempBreakpoint_RunMriDebugException_HitBreakpoint_ClearBreak
 {
     mriInit("MRI_UART_MBED_USB");
 
-    mriCore_SetTempBreakpoint(0xBAADF00D, NULL, NULL);
+    SetTempBreakpoint(0xBAADF00D, NULL, NULL);
 
-    mriPlatform_SetProgramCounter(0xBAADF00D);
+    Platform_SetProgramCounter(0xBAADF00D);
     platformMock_ClearHardwareBreakpointException(memFaultException);
     platformMock_CommInitReceiveChecksummedData("+$c#");
         mriDebugException(platformMock_GetContext());
@@ -257,10 +257,10 @@ TEST(Mri, mriCoreSetTempBreakpoint_RunMriDebugException_WithCallbackReturning0_S
 {
     mriInit("MRI_UART_MBED_USB");
 
-    mriCore_SetTempBreakpoint(0xBAADF00D, testCallback, (void*)this);
+    SetTempBreakpoint(0xBAADF00D, testCallback, (void*)this);
 
     g_callbackReturnValue = 0;
-    mriPlatform_SetProgramCounter(0xBAADF00D);
+    Platform_SetProgramCounter(0xBAADF00D);
     platformMock_CommInitReceiveChecksummedData("+$c#");
         mriDebugException(platformMock_GetContext());
     STRCMP_EQUAL ( platformMock_CommChecksumData("$T05responseT#+"), platformMock_CommGetTransmittedData() );
@@ -274,10 +274,10 @@ TEST(Mri, mriCoreSetTempBreakpoint_RunMriDebugException_WithCallbackReturning1_S
 {
     mriInit("MRI_UART_MBED_USB");
 
-    mriCore_SetTempBreakpoint(0xBAADF00D, testCallback, NULL);
+    SetTempBreakpoint(0xBAADF00D, testCallback, NULL);
 
     g_callbackReturnValue = 1;
-    mriPlatform_SetProgramCounter(0xBAADF00D);
+    Platform_SetProgramCounter(0xBAADF00D);
     platformMock_CommInitReceiveChecksummedData("+$c#");
         mriDebugException(platformMock_GetContext());
     STRCMP_EQUAL ( platformMock_CommChecksumData(""), platformMock_CommGetTransmittedData() );


### PR DESCRIPTION
Minor change.