### PR TITLE
FlagSemihostCallAsHandled skip all action if Semihost_IsDebuggeeMakingSemihostCall return false

### DIFF
--- a/core/mri.c
+++ b/core/mri.c
@@ -463,8 +463,11 @@ int WasSemihostCallCancelledByGdb(void)
 
 void FlagSemihostCallAsHandled(void)
 {
-    Platform_AdvanceProgramCounterToNextInstruction();
-    Platform_SetSemihostCallReturnAndErrnoValues(g_mri.semihostReturnCode, g_mri.semihostErrno);
+    if (Semihost_IsDebuggeeMakingSemihostCall())
+    {
+        Platform_AdvanceProgramCounterToNextInstruction();
+        Platform_SetSemihostCallReturnAndErrnoValues(g_mri.semihostReturnCode, g_mri.semihostErrno);
+    }
 }
 
 


### PR DESCRIPTION
@adamgreen I reopen https://github.com/adamgreen/mri/pull/21 again, because it's relate to how to implement the non-block input from gdb console: https://github.com/adamgreen/mri/issues/26.

If we can invoke semihost operation directly in the thread context, and combine with thread mri(https://github.com/adamgreen/mri/issues/27), it's possible to only block the caller thread(shell) instead the whole device.

Of course, we need add code to protect mri core to avoid the multiple thread access the shared resource concurrently.

Do you think so?