### PR TITLE
Fix hardware single step

### DIFF
--- a/core/cmd_query.c
+++ b/core/cmd_query.c
@@ -102,7 +102,7 @@ uint32_t HandleQueryCommand(void)
 */
 static uint32_t handleQuerySupportedCommand(void)
 {
-    static const char querySupportResponse[] = "qXfer:memory-map:read+;qXfer:features:read+;PacketSize=";
+    static const char querySupportResponse[] = "qXfer:memory-map:read+;qXfer:features:read+;vContSupported+;PacketSize=";
     /* Subtract 4 for packet overhead ('$', '#', and 2-byte checksum) as GDB doesn't count those bytes. */
     uint32_t          PacketSize = Platform_GetPacketBufferSize()-4;
     Buffer*           pBuffer = GetInitializedBuffer();

--- a/tests/tests/cmd_queryTests.cpp
+++ b/tests/tests/cmd_queryTests.cpp
@@ -87,7 +87,7 @@ TEST(cmdQuery, QuerySupported)
     platformMock_CommInitReceiveChecksummedData("+$qSupported#", "+$c#");
         mriDebugException(platformMock_GetContext());
     STRCMP_EQUAL ( platformMock_CommChecksumData("$T05responseT#"
-                                                 "+$qXfer:memory-map:read+;qXfer:features:read+;PacketSize=89#+"),
+                                                 "+$qXfer:memory-map:read+;qXfer:features:read+;vContSupported+;PacketSize=89#+"),
                                                  platformMock_CommGetTransmittedData() );
 }
 


### PR DESCRIPTION
Some gdb versions require the vContSupported+ feature to be exposed to use hardware single stepping; add it to the "qSupported" response string.

I think that the reason that I noticed this is a combination of the following:

- I'm on an AArch64 host machine, so using the standard Debian GDB build for an AArch64 target rather than a special build that might not have this check
- The MCU is behind an MMU (in addition to the MPU), which seems to silently prevent overwriting instructions for software breakpoints

Note that I have not tested the updated unit tests—it's possible that I didn't update them properly.

Thank you for this project; I'm having a lot of fun debugging GPU firmware using a couple of tracebuffers in shared memory between the CPU and GPU for communication. It's pretty powerful for an MCU—a Cortex-M7 which can run at 1 GHz and use at least 1 GB of RAM (and through a mechanism I have not yet determined read and write to 16 different 48-bit virtual address spaces). The rest of the GPU is almost unnecessary :-)
