### PR TITLE
Invalidate instruction cache after memory writes

### DIFF
--- a/architectures/armv7-m/armv7-m.c
+++ b/architectures/armv7-m/armv7-m.c
@@ -1001,6 +1001,21 @@ void Platform_LeavingDebugger(void)
     clearMonitorPending();
 }
 
+void Platform_InvalidateICache(void *pv, uint32_t size)
+{
+#if defined (__ICACHE_PRESENT) && (__ICACHE_PRESENT == 1U)
+    /* Using DCCMVAU rather than DCCMVAC might be more efficient, but
+     * CMSIS doesn't have a function for that. */
+    SCB_CleanDCache_by_Addr(pv, size);
+
+#if __CM_CMSIS_VERSION >= 0x050002
+    SCB_InvalidateICache_by_Addr(pv, size);
+#else
+    SCB_InvalidateICache();
+#endif
+#endif
+}
+
 static void clearControlCFlag(void)
 {
     mriCortexMFlags &= ~CORTEXM_FLAGS_CTRL_C;

--- a/core/cmd_memory.c
+++ b/core/cmd_memory.c
@@ -13,6 +13,7 @@
    limitations under the License.
 */
 /* Handlers for memory related gdb commands. */
+#include <core/platforms.h>
 #include <core/buffer.h>
 #include <core/core.h>
 #include <core/mri.h>
@@ -111,6 +112,8 @@ uint32_t HandleBinaryMemoryWriteCommand(void)
 {
     Buffer*        pBuffer = GetBuffer();
     AddressLength  addressLength;
+    uint32_t*      pv;
+    uint32_t       length;
 
     __try
     {
@@ -122,8 +125,12 @@ uint32_t HandleBinaryMemoryWriteCommand(void)
         return 0;
     }
 
-    if (WriteBinaryBufferToMemory(pBuffer, ADDR32_TO_POINTER(addressLength.address), addressLength.length))
+    pv = ADDR32_TO_POINTER(addressLength.address);
+    length = addressLength.length;
+
+    if (WriteBinaryBufferToMemory(pBuffer, pv, length))
     {
+        Platform_InvalidateICache(pv, length);
         PrepareStringResponse("OK");
     }
     else

--- a/core/platforms.h
+++ b/core/platforms.h
@@ -35,6 +35,7 @@ uint8_t   mriPlatform_MemRead8(const void* pv);
 void      mriPlatform_MemWrite32(void* pv, uint32_t value);
 void      mriPlatform_MemWrite16(void* pv, uint16_t value);
 void      mriPlatform_MemWrite8(void* pv, uint8_t value);
+void      mriPlatform_InvalidateICache(void *pv, uint32_t size);
 
 uint32_t  mriPlatform_CommHasReceiveData(void);
 uint32_t  mriPlatform_CommHasTransmitCompleted(void);
@@ -155,6 +156,7 @@ void            mriPlatform_HandleFaultFromHighPriorityCode(void);
 #define Platform_MemWrite32                                 mriPlatform_MemWrite32
 #define Platform_MemWrite16                                 mriPlatform_MemWrite16
 #define Platform_MemWrite8                                  mriPlatform_MemWrite8
+#define Platform_InvalidateICache                           mriPlatform_InvalidateICache
 #define Platform_CommHasReceiveData                         mriPlatform_CommHasReceiveData
 #define Platform_CommHasTransmitCompleted                   mriPlatform_CommHasTransmitCompleted
 #define Platform_CommReceiveChar                            mriPlatform_CommReceiveChar


### PR DESCRIPTION
GDB uses the 'X' command to set software breakpoints, so invalidate the instruction cache to make sure that the patched-in breakpoint instruction is executed when execution continues.

<hr>

In the Makefile, it appears that `armv7-m.c` is only compiled for the different FPU variants, not based on whether there is a separate instruction cache or not. So if it is compiled against a `cmsis.h` which doesn't define an instruction cache, breakpoints will not work on a device that does.

So maybe the `Platform_InvalidateICache` function should be defined in board-specific code?

However, the Makefile is already broken, with compilation failing like this, at least when using the toolchain from the `gcc-arm-none-eabi` Debian package:

```
Compiling architectures/armv7-m/armv7-m.c for FPU_HARD
In file included from architectures/armv7-m/armv7-m.c:22:
architectures/armv7-m/debug_cm3.h:19:10: fatal error: cmsis.h: No such file or directory
   19 | #include <cmsis.h>
      |          ^~~~~~~~~
compilation terminated.
make: *** [Makefile:299: obj/armv7-m/fpu_hard/architectures/armv7-m/armv7-m.o] Error 1
```

I am using my own Meson project rather than make, which uses my own set of CMSIS headers, so for me this isn't a problem.
