### PR TITLE
Remove architectures/armv7-m/ include prefix from armv7-m_asm.S

### DIFF
--- a/architectures/armv7-m/armv7-m_asm.S
+++ b/architectures/armv7-m/armv7-m_asm.S
@@ -17,7 +17,7 @@
     .code 16
     .syntax unified
 
-    #include <architectures/armv7-m/armv7-m.h>
+    #include "armv7-m.h"
 
 
     /* Bit in LR set to 0 when automatic stacking of floating point registers occurs during exception handling. */


### PR DESCRIPTION
use the same inclusion in armv7-m.c to avoid adding the new search path
